### PR TITLE
GAM: remove requires arg from "min.sp"

### DIFF
--- a/R/RLearner_classif_gam.R
+++ b/R/RLearner_classif_gam.R
@@ -6,7 +6,7 @@ makeRLearner.classif.gam = function() {
     par.set = makeParamSet(
       makeUntypedLearnerParam(id = "formula", default = NULL),
       makeNumericVectorLearnerParam(id = "sp"),
-      makeNumericVectorLearnerParam(id = "min.sp", requires = quote(sp)),
+      makeNumericVectorLearnerParam(id = "min.sp"),
       makeUntypedLearnerParam(id = "in.out", default = NULL),
       makeUntypedLearnerParam(id = "paraPen", default = NULL),
       makeDiscreteLearnerParam(id = "method", default = "GCV.Cp",


### PR DESCRIPTION
`min.sp` requires arg `sp` to be specified but not to a specific value.
So I cannot do `requires = quote(sp = "XY")` and just doing `requires = quote(sp)` does not seem to be valid -> `makeLearner()` fails with 

```
Fehler in makeLearner("classif.gam", family = "binomial", binomial.link = "logit",  : 
  Assertion on 'requires' failed: Must have class 'call', but has class 'name'.
```

So for the moment, just remove it to get it working..